### PR TITLE
feat(client): allow custom api timeout

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -30,6 +30,7 @@ class Client extends EventEmitter {
     this.setOAuth(options)
     this.maxUsePercent = typeof options.maxUsePercent !== 'undefined' ? options.maxUsePercent : MAX_USE_PERCENT_DEFAULT
     this.baseUrl = options.baseUrl || 'http://api.hubapi.com'
+    this.apiTimeout = options.timeout || API_TIMEOUT
     this.apiCalls = 0
     this.on('apiCall', params => {
       debug('apiCall', _.pick(params, ['method', 'url']))
@@ -92,7 +93,7 @@ class Client extends EventEmitter {
       arrayFormat: 'repeat'
     }
 
-    params.timeout = API_TIMEOUT
+    params.timeout = this.apiTimeout;
 
     return this.checkApiLimit(params)
       .then(() => {


### PR DESCRIPTION
Allow api timeout to be specified, or default to API_TIMEOUT const